### PR TITLE
Fix crystal feature compilation errors (14 → 0 errors)


### DIFF
--- a/src/extensions/codebook/hierarchical.rs
+++ b/src/extensions/codebook/hierarchical.rs
@@ -146,7 +146,7 @@ impl Projection {
     pub fn new() -> Self {
         // Generate P random hyperplanes
         let hyperplanes: Vec<Fingerprint> = (0..P)
-            .map(|i| Fingerprint::from_seed(0xPR0JECT10N + i as u64))
+            .map(|i| Fingerprint::from_seed(0xBADC0DE710 + i as u64))
             .collect();
         
         Self { hyperplanes }

--- a/src/extensions/codebook_training.rs
+++ b/src/extensions/codebook_training.rs
@@ -105,7 +105,7 @@ pub struct KeywordWeights {
     momentum: f32,
     
     /// Previous gradients (for momentum)
-    prev_gradients: HashMap<String, Vec<f32>>,
+    prev_gradients: HashMap<String, f32>,
 }
 
 impl Default for KeywordWeights {

--- a/src/extensions/context_crystal.rs
+++ b/src/extensions/context_crystal.rs
@@ -177,8 +177,12 @@ impl Default for ContextCrystal {
 
 impl ContextCrystal {
     pub fn new() -> Self {
-        // Initialize all cells to zero
-        let cells = Box::new([[[const { Fingerprint::zero() }; GRID]; GRID]; GRID]);
+        // Initialize all cells to zero using from_fn (Fingerprint doesn't impl Copy)
+        let cells = Box::new(core::array::from_fn(|_| {
+            core::array::from_fn(|_| {
+                core::array::from_fn(|_| Fingerprint::zero())
+            })
+        }));
         Self {
             cells,
             counts: [[[0u32; GRID]; GRID]; GRID],

--- a/src/extensions/crystal_lm.rs
+++ b/src/extensions/crystal_lm.rs
@@ -111,12 +111,12 @@ impl CrystalAxes {
         if bytes.len() < 3750 {
             return None;
         }
-        
+
         let chunk_size = 10000 / 8;
         Some(Self {
-            temporal: Fingerprint::from_bytes(&bytes[0..chunk_size])?,
-            structural: Fingerprint::from_bytes(&bytes[chunk_size..chunk_size*2])?,
-            depth: Fingerprint::from_bytes(&bytes[chunk_size*2..chunk_size*3])?,
+            temporal: Fingerprint::from_bytes(&bytes[0..chunk_size]).ok()?,
+            structural: Fingerprint::from_bytes(&bytes[chunk_size..chunk_size*2]).ok()?,
+            depth: Fingerprint::from_bytes(&bytes[chunk_size*2..chunk_size*3]).ok()?,
         })
     }
 }
@@ -178,7 +178,11 @@ impl CrystalLM {
     /// Train from (input, output) text pairs
     pub fn train(&mut self, pairs: &[(String, String)]) {
         // Phase 1: Build 5×5×5 crystal from training data
-        let mut crystal = [[[Vec::<Fingerprint>::new(); 5]; 5]; 5];
+        let mut crystal: [[[Vec<Fingerprint>; 5]; 5]; 5] = core::array::from_fn(|_| {
+            core::array::from_fn(|_| {
+                core::array::from_fn(|_| Vec::new())
+            })
+        });
         
         for (input, output) in pairs {
             // Encode with cleaning
@@ -199,7 +203,11 @@ impl CrystalLM {
         }
         
         // Phase 2: Bundle each cell (noise elimination via majority voting)
-        let mut bundled_crystal = [[[Fingerprint::zero(); 5]; 5]; 5];
+        let mut bundled_crystal: [[[Fingerprint; 5]; 5]; 5] = core::array::from_fn(|_| {
+            core::array::from_fn(|_| {
+                core::array::from_fn(|_| Fingerprint::zero())
+            })
+        });
         
         for t in 0..5 {
             for s in 0..5 {

--- a/src/extensions/nsm_substrate.rs
+++ b/src/extensions/nsm_substrate.rs
@@ -524,7 +524,11 @@ impl MetacognitiveSubstrate {
     pub fn new() -> Self {
         Self {
             codebook: NsmCodebook::new(),
-            crystal: [[[const { Fingerprint::zero() }; 5]; 5]; 5],
+            crystal: core::array::from_fn(|_| {
+                core::array::from_fn(|_| {
+                    core::array::from_fn(|_| Fingerprint::zero())
+                })
+            }),
             concepts: HashMap::new(),
             tick: 0,
         }

--- a/src/extensions/spo/spo.rs
+++ b/src/extensions/spo/spo.rs
@@ -1392,8 +1392,8 @@ fn test_cypher_comparison() {
 // JINA CACHE DEMONSTRATION
 // ============================================================================
 
-mod jina_cache;
-mod jina_api;
+// jina_cache and jina_api are declared in mod.rs, use super:: to access
+use super::jina_cache;
 
 fn test_jina_cache() {
     println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");


### PR DESCRIPTION

Fixes:
- Remove duplicate mod declarations in spo.rs (use super::jina_cache)
- Fix invalid hex literal 0xPR0JECT10N → 0xBADC0DE710
- Use core::array::from_fn for 3D Fingerprint arrays (no Copy trait)
- Change prev_gradients HashMap<String, Vec<f32>> → f32 (type mismatch)
- Add .ok()? for Result→Option in CrystalAxes::from_bytes

Files modified:
- src/extensions/spo/spo.rs
- src/extensions/codebook/hierarchical.rs
- src/extensions/context_crystal.rs
- src/extensions/nsm_substrate.rs
- src/extensions/crystal_lm.rs
- src/extensions/codebook_training.rs

Test results with --features "spo,quantum,codebook":
- Before: 0 passed (14 compile errors)
- After: 173 passed, 10 failed

https://claude.ai/code/session_01CSyicPmyQZ88KUNd2RW3Kk