### PR TITLE
fix: Use compact JSON to work around server parser bug

### DIFF
--- a/sdk/python/ladybugdb.py
+++ b/sdk/python/ladybugdb.py
@@ -176,7 +176,9 @@ class Client:
         """Make HTTP request."""
         url = f"{self.url}{path}"
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        body = json.dumps(data).encode() if data else None
+        # CRITICAL: Server has non-conformant JSON parser that breaks on
+        # whitespace after ':'. Use compact separators to avoid spaces.
+        body = json.dumps(data, separators=(",", ":")).encode() if data else None
 
         req = Request(url, data=body, headers=headers, method=method)
 


### PR DESCRIPTION
The ladybug-rs server has a non-conformant JSON parser that breaks on standard JSON whitespace after ':'. For example:
  {"a": "b"}  - FAILS (space after colon)
  {"a":"b"}   - WORKS (no space)

This caused silent failures across all 18 POST endpoints:
- hamming returned distance=0 for different strings
- NARS inference returned wrong values
- fingerprint creation returned corrupted data

Fix: Use json.dumps(data, separators=(",", ":")) to produce compact JSON without spaces.

https://claude.ai/code/session_01CSyicPmyQZ88KUNd2RW3Kk