### PR TITLE
fix: Rust 2024 reserved keyword gen → r#gen

### DIFF
--- a/src/extensions/compress/compress.rs
+++ b/src/extensions/compress/compress.rs
@@ -30,7 +30,7 @@ impl Fingerprint {
     pub fn from_seed(seed: u64) -> Self {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let mut data = [0u64; N64];
-        for w in &mut data { *w = rng.gen(); }
+        for w in &mut data { *w = rng.r#gen(); }
         Self { data }
     }
     pub fn from_text(text: &str) -> Self {
@@ -178,7 +178,7 @@ impl CrystalCodebook {
                     (min_d as f64).powi(2)
                 }).collect();
             let total: f64 = distances.iter().sum();
-            let thresh = rng.gen::<f64>() * total;
+            let thresh = rng.r#gen::<f64>() * total;
             let mut cum = 0.0;
             for (i, d) in distances.iter().enumerate() {
                 cum += d;
@@ -280,7 +280,7 @@ impl BTRProcella {
     
     pub fn choose(&self, state: (f64, f64, f64)) -> RLAction {
         let mut rng = rand::rng();
-        if rng.gen::<f64>() < self.epsilon {
+        if rng.r#gen::<f64>() < self.epsilon {
             match rng.gen_range(0..4) {
                 0 => RLAction::IncreaseResidual,
                 1 => RLAction::DecreaseResidual,

--- a/src/extensions/spo/spo.rs
+++ b/src/extensions/spo/spo.rs
@@ -37,14 +37,14 @@ impl Fingerprint {
     fn random() -> Self {
         let mut rng = rand::rng();
         let mut data = [0u64; N64];
-        for w in &mut data { *w = rng.gen(); }
+        for w in &mut data { *w = rng.r#gen(); }
         Self { data }
     }
     
     fn from_seed(seed: u64) -> Self {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let mut data = [0u64; N64];
-        for w in &mut data { *w = rng.gen(); }
+        for w in &mut data { *w = rng.r#gen(); }
         Self { data }
     }
     
@@ -115,7 +115,7 @@ impl Fingerprint {
         let mut rng = rand::rng();
         for i in 0..N64 {
             for bit in 0..64 {
-                if (overlap.data[i] >> bit) & 1 == 1 && rng.gen::<f64>() < flip_prob {
+                if (overlap.data[i] >> bit) & 1 == 1 && rng.r#gen::<f64>() < flip_prob {
                     result.data[i] ^= 1 << bit;
                 }
             }


### PR DESCRIPTION
## Summary
Fix for Rust 2024 edition compatibility where `gen` becomes a reserved keyword.

## Changes
- `src/extensions/compress/compress.rs`: `rng.gen()` → `rng.r#gen()`
- `src/extensions/spo/spo.rs`: `rng.gen()` → `rng.r#gen()`

**Note**: `gen_range()` is unaffected as it's a method name, not the `gen` keyword.

## Supersedes
This PR supersedes #62 which had the same fix but was based on outdated code (before PR #58 Grammar Layer merge), causing merge conflicts.

Closes #62