### PR TITLE
feat: Add crewAI orchestration layer with A2A protocol, thinking templates, and agent blackboards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ compress = ["lz4"]               # Compression support
 quantum = []                     # Quantum-inspired operators
 bench = []                       # Benchmark suite (comparison vs Qdrant/Milvus)
 flight = ["arrow-flight", "tonic", "prost"]  # Arrow Flight MCP server
+crewai = ["flight"]                          # crewAI orchestration (A2A, agent cards, thinking templates)
 
 # All features
 full = [

--- a/src/flight/mod.rs
+++ b/src/flight/mod.rs
@@ -34,6 +34,9 @@ mod server;
 mod actions;
 mod capabilities;
 
+#[cfg(feature = "crewai")]
+pub mod crew_actions;
+
 #[cfg(feature = "flight")]
 pub use server::LadybugFlightService;
 #[cfg(feature = "flight")]
@@ -45,6 +48,10 @@ pub use capabilities::{
     TransportAdapter, TransportError,
     PythonClientConfig,
 };
+
+// crewAI orchestration actions
+#[cfg(feature = "crewai")]
+pub use crew_actions::execute_crew_action;
 
 // Legacy JSON types are only available with json_fallback feature
 #[cfg(all(feature = "flight", feature = "json_fallback"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@ pub mod bench;
 #[cfg(feature = "flight")]
 pub mod flight;
 
+#[cfg(feature = "crewai")]
+pub mod orchestration;
+
 // === Re-exports for convenience ===
 
 // Core types
@@ -107,6 +110,16 @@ pub use crate::query::{Query, QueryResult, cypher_to_sql, SqlEngine, QueryBuilde
 // Storage
 #[cfg(feature = "lancedb")]
 pub use crate::storage::{Database, LanceStore, NodeRecord, EdgeRecord};
+
+// Orchestration (crewAI integration)
+#[cfg(feature = "crewai")]
+pub use crate::orchestration::{
+    AgentCard, AgentRegistry, AgentCapability, AgentRole, AgentGoal,
+    ThinkingTemplate, ThinkingTemplateRegistry, StyleOverride,
+    A2AMessage, A2AChannel, A2AProtocol, MessageKind,
+    AgentBlackboard, AgentAwareness, BlackboardRegistry,
+    CrewBridge, CrewTask, CrewDispatch, TaskStatus, DispatchResult,
+};
 
 // === Error types ===
 

--- a/src/orchestration/a2a.rs
+++ b/src/orchestration/a2a.rs
@@ -1,0 +1,262 @@
+//! A2A — Agent-to-Agent Protocol via BindSpace 0x0F
+//!
+//! Non-blocking message routing between agents through dedicated BindSpace
+//! addresses. Each A2A channel occupies a slot in prefix 0x0F.
+//!
+//! # Channel Addressing
+//!
+//! ```text
+//! 0x0F:XX where XX = hash(sender_slot, receiver_slot) & 0xFF
+//! ```
+//!
+//! Messages are serialized into the fingerprint field using XOR composition,
+//! allowing multiple messages to be stacked and retrieved via unbinding.
+//!
+//! # Protocol Flow
+//!
+//! ```text
+//! Agent A (0x0C:02) ──► encode message ──► XOR bind to channel ──► 0x0F:hash(02,05)
+//!                                                                        │
+//! Agent B (0x0C:05) ◄── decode message ◄── XOR unbind from channel ◄─────┘
+//! ```
+
+use serde::{Deserialize, Serialize};
+use crate::storage::bind_space::{
+    Addr, BindSpace, FINGERPRINT_WORDS, PREFIX_A2A,
+};
+
+/// Message kind for A2A communication
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MessageKind {
+    /// Task delegation request
+    Delegate,
+    /// Result from delegated task
+    Result,
+    /// Status update / heartbeat
+    Status,
+    /// Knowledge sharing (fingerprint payload)
+    Knowledge,
+    /// Coordination signal (sync point)
+    Sync,
+    /// Query to another agent
+    Query,
+    /// Response to a query
+    Response,
+}
+
+/// Delivery status for A2A messages
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DeliveryStatus {
+    Pending,
+    Delivered,
+    Acknowledged,
+    Failed,
+}
+
+/// A2A message between agents
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct A2AMessage {
+    pub id: String,
+    pub sender_slot: u8,
+    pub receiver_slot: u8,
+    pub kind: MessageKind,
+    pub payload: String,
+    /// Optional fingerprint payload for knowledge transfer
+    #[serde(skip)]
+    pub fingerprint: Option<[u64; FINGERPRINT_WORDS]>,
+    pub timestamp: u64,
+    pub status: DeliveryStatus,
+    /// Thinking style hint for the receiver
+    pub thinking_style_hint: Option<String>,
+}
+
+impl A2AMessage {
+    /// Compute the channel address for this message
+    pub fn channel_addr(&self) -> Addr {
+        let channel = compute_channel(self.sender_slot, self.receiver_slot);
+        Addr::new(PREFIX_A2A, channel)
+    }
+
+    /// Encode message metadata into a fingerprint for channel storage
+    pub fn to_fingerprint(&self) -> [u64; FINGERPRINT_WORDS] {
+        use sha2::{Sha256, Digest};
+
+        let serialized = format!(
+            "{}:{}:{}:{:?}:{}",
+            self.id, self.sender_slot, self.receiver_slot,
+            self.kind, self.payload
+        );
+
+        let mut hasher = Sha256::new();
+        hasher.update(serialized.as_bytes());
+        let hash = hasher.finalize();
+
+        let mut fp = [0u64; FINGERPRINT_WORDS];
+        for (i, word) in fp.iter_mut().enumerate() {
+            let mut h = Sha256::new();
+            h.update(&hash);
+            h.update(&(i as u32).to_le_bytes());
+            let block = h.finalize();
+            *word = u64::from_le_bytes(block[..8].try_into().unwrap());
+        }
+        fp
+    }
+}
+
+/// A2A channel — a named communication path between two agents
+#[derive(Clone, Debug)]
+pub struct A2AChannel {
+    pub sender_slot: u8,
+    pub receiver_slot: u8,
+    pub channel_slot: u8,
+    pub message_count: u32,
+}
+
+impl A2AChannel {
+    pub fn new(sender: u8, receiver: u8) -> Self {
+        Self {
+            sender_slot: sender,
+            receiver_slot: receiver,
+            channel_slot: compute_channel(sender, receiver),
+            message_count: 0,
+        }
+    }
+
+    pub fn addr(&self) -> Addr {
+        Addr::new(PREFIX_A2A, self.channel_slot)
+    }
+}
+
+/// Compute channel slot from sender/receiver pair
+/// Uses XOR + rotation to distribute channels across the 256-slot space
+fn compute_channel(sender: u8, receiver: u8) -> u8 {
+    // XOR sender and receiver, then mix with rotation to reduce collisions
+    let mixed = sender ^ receiver;
+    let rotated = sender.wrapping_mul(17).wrapping_add(receiver.wrapping_mul(31));
+    mixed ^ rotated
+}
+
+/// A2A protocol manager
+pub struct A2AProtocol {
+    channels: Vec<A2AChannel>,
+    pending_messages: Vec<A2AMessage>,
+}
+
+impl A2AProtocol {
+    pub fn new() -> Self {
+        Self {
+            channels: Vec::new(),
+            pending_messages: Vec::new(),
+        }
+    }
+
+    /// Open a channel between two agents
+    pub fn open_channel(&mut self, sender: u8, receiver: u8) -> A2AChannel {
+        let channel = A2AChannel::new(sender, receiver);
+        self.channels.push(channel.clone());
+        channel
+    }
+
+    /// Send a message through the protocol
+    pub fn send(&mut self, msg: A2AMessage, space: &mut BindSpace) -> DeliveryStatus {
+        let addr = msg.channel_addr();
+        let fp = msg.to_fingerprint();
+
+        // XOR-compose into the channel's fingerprint slot
+        if let Some(node) = space.read(addr) {
+            let mut composed = node.fingerprint;
+            for (i, word) in composed.iter_mut().enumerate() {
+                *word ^= fp[i];
+            }
+            space.write_at(addr, composed);
+        } else {
+            space.write_at(addr, fp);
+        }
+
+        if let Some(node) = space.read_mut(addr) {
+            node.label = Some(format!(
+                "a2a:{}->{}",
+                msg.sender_slot, msg.receiver_slot
+            ));
+        }
+
+        self.pending_messages.push(msg);
+        DeliveryStatus::Delivered
+    }
+
+    /// Receive pending messages for a given agent slot
+    pub fn receive(&mut self, receiver_slot: u8) -> Vec<A2AMessage> {
+        let mut received = Vec::new();
+        self.pending_messages.retain(|msg| {
+            if msg.receiver_slot == receiver_slot && msg.status == DeliveryStatus::Pending {
+                let mut msg = msg.clone();
+                msg.status = DeliveryStatus::Delivered;
+                received.push(msg);
+                false
+            } else {
+                true
+            }
+        });
+        received
+    }
+
+    /// List active channels
+    pub fn channels(&self) -> &[A2AChannel] {
+        &self.channels
+    }
+
+    /// Get pending message count for a receiver
+    pub fn pending_for(&self, receiver_slot: u8) -> usize {
+        self.pending_messages
+            .iter()
+            .filter(|m| m.receiver_slot == receiver_slot && m.status == DeliveryStatus::Pending)
+            .count()
+    }
+}
+
+impl Default for A2AProtocol {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_channel_addressing() {
+        let ch = A2AChannel::new(0x02, 0x05);
+        assert_eq!(ch.addr().prefix(), PREFIX_A2A);
+        // Channel slot is deterministic
+        let ch2 = A2AChannel::new(0x02, 0x05);
+        assert_eq!(ch.channel_slot, ch2.channel_slot);
+    }
+
+    #[test]
+    fn test_channel_asymmetry() {
+        // sender→receiver and receiver→sender should use different channels
+        let ch_ab = A2AChannel::new(0x02, 0x05);
+        let ch_ba = A2AChannel::new(0x05, 0x02);
+        assert_ne!(ch_ab.channel_slot, ch_ba.channel_slot);
+    }
+
+    #[test]
+    fn test_message_fingerprint_deterministic() {
+        let msg = A2AMessage {
+            id: "msg-1".to_string(),
+            sender_slot: 0,
+            receiver_slot: 1,
+            kind: MessageKind::Delegate,
+            payload: "do the thing".to_string(),
+            fingerprint: None,
+            timestamp: 12345,
+            status: DeliveryStatus::Pending,
+            thinking_style_hint: Some("analytical".to_string()),
+        };
+
+        let fp1 = msg.to_fingerprint();
+        let fp2 = msg.to_fingerprint();
+        assert_eq!(fp1, fp2);
+    }
+}

--- a/src/orchestration/agent_card.rs
+++ b/src/orchestration/agent_card.rs
@@ -1,0 +1,300 @@
+//! Agent Card — crewAI agent definition mapped to BindSpace 0x0C
+//!
+//! Each agent card occupies a slot in prefix 0x0C.
+//! Slots 0x00-0x7F: agent definitions (128 agents max)
+//! Slots 0x80-0xFF: capability fingerprints (1:1 with agent slot)
+//!
+//! Compatible with crewAI's agents.yaml format.
+
+use serde::{Deserialize, Serialize};
+use crate::cognitive::ThinkingStyle;
+use crate::storage::bind_space::{
+    Addr, BindSpace, FINGERPRINT_WORDS,
+    PREFIX_AGENTS, SLOT_SUBDIVISION,
+};
+
+/// Agent role mirrors crewAI's role field
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentRole {
+    pub name: String,
+    pub description: String,
+}
+
+/// Agent goal — what the agent is trying to achieve
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentGoal {
+    pub objective: String,
+    pub success_criteria: Vec<String>,
+    pub constraints: Vec<String>,
+}
+
+/// Agent capability — tool or skill the agent can use
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentCapability {
+    pub name: String,
+    pub description: String,
+    /// CAM opcode this capability maps to (0x000-0xFFF)
+    pub cam_opcode: Option<u16>,
+    /// Whether this capability requires sci/v1 validation
+    pub requires_validation: bool,
+}
+
+/// Agent card — full agent definition compatible with crewAI agents.yaml
+///
+/// Maps to BindSpace prefix 0x0C.
+/// The agent's fingerprint encodes its role + goal + backstory
+/// for similarity-based agent selection via HDR cascade.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentCard {
+    /// Unique agent identifier (maps to slot in 0x0C:XX)
+    pub id: String,
+    /// Human-readable name
+    pub name: String,
+    /// Agent role (crewAI compatible)
+    pub role: AgentRole,
+    /// Agent goal
+    pub goal: AgentGoal,
+    /// Backstory / system prompt context
+    pub backstory: String,
+    /// Thinking style for this agent
+    pub thinking_style: String,
+    /// Available capabilities/tools
+    pub capabilities: Vec<AgentCapability>,
+    /// Whether the agent can delegate to others
+    pub allow_delegation: bool,
+    /// Memory enabled (maps to blackboard at 0x0E)
+    pub memory: bool,
+    /// Verbose output
+    pub verbose: bool,
+    /// Maximum iterations before stopping
+    pub max_iter: u32,
+    /// BindSpace slot assigned to this agent (0x00-0x7F)
+    pub slot: Option<u8>,
+}
+
+impl AgentCard {
+    /// Parse thinking_style field to ThinkingStyle enum
+    pub fn resolve_thinking_style(&self) -> ThinkingStyle {
+        match self.thinking_style.to_lowercase().as_str() {
+            "analytical" => ThinkingStyle::Analytical,
+            "convergent" => ThinkingStyle::Convergent,
+            "systematic" => ThinkingStyle::Systematic,
+            "creative" => ThinkingStyle::Creative,
+            "divergent" => ThinkingStyle::Divergent,
+            "exploratory" => ThinkingStyle::Exploratory,
+            "focused" => ThinkingStyle::Focused,
+            "diffuse" => ThinkingStyle::Diffuse,
+            "peripheral" => ThinkingStyle::Peripheral,
+            "intuitive" => ThinkingStyle::Intuitive,
+            "deliberate" => ThinkingStyle::Deliberate,
+            "metacognitive" => ThinkingStyle::Metacognitive,
+            _ => ThinkingStyle::Deliberate,
+        }
+    }
+
+    /// Get the BindSpace address for this agent's card
+    pub fn card_addr(&self) -> Option<Addr> {
+        self.slot.map(|s| Addr::new(PREFIX_AGENTS, s))
+    }
+
+    /// Get the BindSpace address for this agent's capability fingerprint
+    pub fn capability_addr(&self) -> Option<Addr> {
+        self.slot.map(|s| Addr::new(PREFIX_AGENTS, s | SLOT_SUBDIVISION))
+    }
+
+    /// Generate a fingerprint from the agent's identity
+    /// (role + goal + backstory → SHA256 → expanded to 10K bits)
+    pub fn identity_fingerprint(&self) -> [u64; FINGERPRINT_WORDS] {
+        use sha2::{Sha256, Digest};
+
+        let identity = format!(
+            "{}:{}:{}:{}",
+            self.role.name, self.role.description,
+            self.goal.objective, self.backstory
+        );
+
+        let mut hasher = Sha256::new();
+        hasher.update(identity.as_bytes());
+        let hash = hasher.finalize();
+
+        let mut fp = [0u64; FINGERPRINT_WORDS];
+        for (i, word) in fp.iter_mut().enumerate() {
+            let mut h = Sha256::new();
+            h.update(&hash);
+            h.update(&(i as u32).to_le_bytes());
+            let block = h.finalize();
+            *word = u64::from_le_bytes(block[..8].try_into().unwrap());
+        }
+        fp
+    }
+}
+
+impl Default for AgentCard {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            role: AgentRole {
+                name: "assistant".to_string(),
+                description: "General-purpose assistant".to_string(),
+            },
+            goal: AgentGoal {
+                objective: String::new(),
+                success_criteria: Vec::new(),
+                constraints: Vec::new(),
+            },
+            backstory: String::new(),
+            thinking_style: "deliberate".to_string(),
+            capabilities: Vec::new(),
+            allow_delegation: false,
+            memory: true,
+            verbose: false,
+            max_iter: 25,
+            slot: None,
+        }
+    }
+}
+
+/// Agent registry — manages all agents in prefix 0x0C
+pub struct AgentRegistry {
+    agents: Vec<AgentCard>,
+    next_slot: u8,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self {
+            agents: Vec::new(),
+            next_slot: 0,
+        }
+    }
+
+    /// Register an agent, assigning it the next available slot
+    pub fn register(&mut self, mut card: AgentCard) -> Result<Addr, String> {
+        if self.next_slot >= SLOT_SUBDIVISION {
+            return Err("Agent registry full (128 max)".to_string());
+        }
+
+        card.slot = Some(self.next_slot);
+        let addr = Addr::new(PREFIX_AGENTS, self.next_slot);
+        self.agents.push(card);
+        self.next_slot += 1;
+        Ok(addr)
+    }
+
+    /// Bind all registered agents into BindSpace
+    pub fn bind_all(&self, space: &mut BindSpace) {
+        for card in &self.agents {
+            if let Some(slot) = card.slot {
+                let addr = Addr::new(PREFIX_AGENTS, slot);
+                let fp = card.identity_fingerprint();
+                space.write_at(addr, fp);
+                if let Some(node) = space.read_mut(addr) {
+                    node.label = Some(format!("agent:{}", card.id));
+                }
+            }
+        }
+    }
+
+    /// Parse agents from YAML (crewAI agents.yaml format)
+    pub fn from_yaml(yaml: &str) -> Result<Vec<AgentCard>, String> {
+        serde_yml::from_str(yaml).map_err(|e| format!("YAML parse error: {}", e))
+    }
+
+    /// Get agent by slot
+    pub fn get(&self, slot: u8) -> Option<&AgentCard> {
+        self.agents.iter().find(|a| a.slot == Some(slot))
+    }
+
+    /// Get agent by id
+    pub fn get_by_id(&self, id: &str) -> Option<&AgentCard> {
+        self.agents.iter().find(|a| a.id == id)
+    }
+
+    /// List all registered agents
+    pub fn list(&self) -> &[AgentCard] {
+        &self.agents
+    }
+
+    /// Count of registered agents
+    pub fn count(&self) -> usize {
+        self.agents.len()
+    }
+}
+
+impl Default for AgentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_card_yaml_roundtrip() {
+        let card = AgentCard {
+            id: "researcher".to_string(),
+            name: "Research Agent".to_string(),
+            role: AgentRole {
+                name: "researcher".to_string(),
+                description: "Performs deep research on scientific topics".to_string(),
+            },
+            goal: AgentGoal {
+                objective: "Find and validate scientific claims".to_string(),
+                success_criteria: vec!["p < 0.05".to_string()],
+                constraints: vec!["Use sci/v1 validation".to_string()],
+            },
+            backstory: "Expert in statistical analysis".to_string(),
+            thinking_style: "analytical".to_string(),
+            capabilities: vec![AgentCapability {
+                name: "sci_query".to_string(),
+                description: "Query sci/v1 endpoints".to_string(),
+                cam_opcode: Some(0x060),
+                requires_validation: true,
+            }],
+            allow_delegation: true,
+            memory: true,
+            verbose: false,
+            max_iter: 25,
+            slot: None,
+        };
+
+        let yaml = serde_yml::to_string(&card).unwrap();
+        let parsed: AgentCard = serde_yml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.id, "researcher");
+        assert_eq!(parsed.resolve_thinking_style(), ThinkingStyle::Analytical);
+    }
+
+    #[test]
+    fn test_agent_registry() {
+        let mut registry = AgentRegistry::new();
+
+        let card = AgentCard {
+            id: "agent-0".to_string(),
+            ..Default::default()
+        };
+
+        let addr = registry.register(card).unwrap();
+        assert_eq!(addr.prefix(), PREFIX_AGENTS);
+        assert_eq!(addr.slot(), 0);
+        assert_eq!(registry.count(), 1);
+    }
+
+    #[test]
+    fn test_identity_fingerprint_deterministic() {
+        let card = AgentCard {
+            id: "test".to_string(),
+            role: AgentRole {
+                name: "tester".to_string(),
+                description: "Tests things".to_string(),
+            },
+            ..Default::default()
+        };
+
+        let fp1 = card.identity_fingerprint();
+        let fp2 = card.identity_fingerprint();
+        assert_eq!(fp1, fp2);
+    }
+}

--- a/src/orchestration/blackboard_agent.rs
+++ b/src/orchestration/blackboard_agent.rs
@@ -1,0 +1,287 @@
+//! Agent Blackboard — Per-agent ice-caked awareness via BindSpace 0x0E
+//!
+//! Each agent gets a dedicated blackboard slot in prefix 0x0E that mirrors
+//! their agent slot in 0x0C. This provides persistent, agent-specific
+//! state that survives across task executions.
+//!
+//! # Slot Mapping
+//!
+//! ```text
+//! Agent at 0x0C:03 → Blackboard at 0x0E:03
+//! Agent at 0x0C:10 → Blackboard at 0x0E:10
+//! ```
+
+use serde::{Deserialize, Serialize};
+use crate::cognitive::ThinkingStyle;
+use crate::storage::bind_space::{
+    Addr, BindSpace, FINGERPRINT_WORDS,
+    PREFIX_BLACKBOARD, PREFIX_AGENTS,
+};
+
+/// Agent awareness state — what the agent knows about itself and its context
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentAwareness {
+    /// Current thinking style in use
+    pub active_style: String,
+    /// Coherence level (0.0-1.0) of current reasoning
+    pub coherence: f32,
+    /// Current task progress (0.0-1.0)
+    pub progress: f32,
+    /// Ice-caked decisions (frozen commitments)
+    pub ice_caked: Vec<String>,
+    /// Active goals from agent card
+    pub active_goals: Vec<String>,
+    /// Tools currently available
+    pub available_tools: Vec<String>,
+    /// Recent resonance hits (addresses that matched)
+    pub resonance_hits: Vec<u16>,
+    /// Number of A2A messages pending
+    pub pending_messages: u32,
+}
+
+impl Default for AgentAwareness {
+    fn default() -> Self {
+        Self {
+            active_style: "deliberate".to_string(),
+            coherence: 0.0,
+            progress: 0.0,
+            ice_caked: Vec::new(),
+            active_goals: Vec::new(),
+            available_tools: Vec::new(),
+            resonance_hits: Vec::new(),
+            pending_messages: 0,
+        }
+    }
+}
+
+/// Per-agent blackboard stored at prefix 0x0E
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AgentBlackboard {
+    /// Agent slot (mirrors 0x0C slot)
+    pub agent_slot: u8,
+    /// Agent identifier
+    pub agent_id: String,
+    /// Current awareness state
+    pub awareness: AgentAwareness,
+    /// Task history (last N completed tasks)
+    pub task_history: Vec<TaskRecord>,
+    /// Accumulated knowledge fingerprints (addresses learned)
+    pub knowledge_addrs: Vec<u16>,
+    /// Session cycle counter
+    pub cycle: u64,
+}
+
+/// Record of a completed task
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TaskRecord {
+    pub task_id: String,
+    pub description: String,
+    pub outcome: String,
+    pub thinking_style_used: String,
+    pub cycle: u64,
+}
+
+impl AgentBlackboard {
+    pub fn new(agent_slot: u8, agent_id: &str) -> Self {
+        Self {
+            agent_slot,
+            agent_id: agent_id.to_string(),
+            awareness: AgentAwareness::default(),
+            task_history: Vec::new(),
+            knowledge_addrs: Vec::new(),
+            cycle: 0,
+        }
+    }
+
+    /// BindSpace address for this blackboard
+    pub fn addr(&self) -> Addr {
+        Addr::new(PREFIX_BLACKBOARD, self.agent_slot)
+    }
+
+    /// Corresponding agent card address
+    pub fn agent_addr(&self) -> Addr {
+        Addr::new(PREFIX_AGENTS, self.agent_slot)
+    }
+
+    /// Update awareness with current thinking style
+    pub fn set_thinking_style(&mut self, style: ThinkingStyle) {
+        self.awareness.active_style = format!("{:?}", style).to_lowercase();
+    }
+
+    /// Record a completed task
+    pub fn record_task(&mut self, task_id: &str, description: &str, outcome: &str, style: &str) {
+        self.task_history.push(TaskRecord {
+            task_id: task_id.to_string(),
+            description: description.to_string(),
+            outcome: outcome.to_string(),
+            thinking_style_used: style.to_string(),
+            cycle: self.cycle,
+        });
+        // Keep last 50 tasks
+        if self.task_history.len() > 50 {
+            self.task_history.remove(0);
+        }
+    }
+
+    /// Ice-cake a decision (freeze a commitment)
+    pub fn ice_cake(&mut self, decision: &str) {
+        self.awareness.ice_caked.push(decision.to_string());
+    }
+
+    /// Learn an address (add to knowledge base)
+    pub fn learn_address(&mut self, addr: u16) {
+        if !self.knowledge_addrs.contains(&addr) {
+            self.knowledge_addrs.push(addr);
+        }
+    }
+
+    /// Advance cycle counter
+    pub fn tick(&mut self) {
+        self.cycle += 1;
+    }
+
+    /// Generate a state fingerprint for BindSpace storage.
+    /// Encodes awareness + knowledge into a fingerprint that enables
+    /// similarity search between agent states.
+    pub fn state_fingerprint(&self) -> [u64; FINGERPRINT_WORDS] {
+        use sha2::{Sha256, Digest};
+
+        let state = format!(
+            "{}:{}:{}:{}:{}",
+            self.agent_id,
+            self.awareness.active_style,
+            self.awareness.coherence,
+            self.cycle,
+            self.knowledge_addrs.len()
+        );
+
+        let mut hasher = Sha256::new();
+        hasher.update(state.as_bytes());
+        let hash = hasher.finalize();
+
+        let mut fp = [0u64; FINGERPRINT_WORDS];
+        for (i, word) in fp.iter_mut().enumerate() {
+            let mut h = Sha256::new();
+            h.update(&hash);
+            h.update(&(i as u32).to_le_bytes());
+            let block = h.finalize();
+            *word = u64::from_le_bytes(block[..8].try_into().unwrap());
+        }
+
+        // XOR in knowledge addresses for content-based matching
+        for &addr in &self.knowledge_addrs {
+            let word_idx = (addr as usize) % FINGERPRINT_WORDS;
+            fp[word_idx] ^= (addr as u64).wrapping_mul(0x9E3779B97F4A7C15); // Fibonacci hashing
+        }
+
+        fp
+    }
+
+    /// Serialize to YAML for handover
+    pub fn to_yaml(&self) -> String {
+        serde_yml::to_string(self).unwrap_or_default()
+    }
+
+    /// Serialize to JSON
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_default()
+    }
+}
+
+/// Registry managing all agent blackboards
+pub struct BlackboardRegistry {
+    blackboards: Vec<AgentBlackboard>,
+}
+
+impl BlackboardRegistry {
+    pub fn new() -> Self {
+        Self {
+            blackboards: Vec::new(),
+        }
+    }
+
+    /// Create a new blackboard for an agent
+    pub fn create(&mut self, agent_slot: u8, agent_id: &str) -> &mut AgentBlackboard {
+        let bb = AgentBlackboard::new(agent_slot, agent_id);
+        self.blackboards.push(bb);
+        self.blackboards.last_mut().unwrap()
+    }
+
+    /// Get blackboard by agent slot
+    pub fn get(&self, agent_slot: u8) -> Option<&AgentBlackboard> {
+        self.blackboards.iter().find(|b| b.agent_slot == agent_slot)
+    }
+
+    /// Get mutable blackboard by agent slot
+    pub fn get_mut(&mut self, agent_slot: u8) -> Option<&mut AgentBlackboard> {
+        self.blackboards.iter_mut().find(|b| b.agent_slot == agent_slot)
+    }
+
+    /// Bind all blackboard states into BindSpace
+    pub fn bind_all(&self, space: &mut BindSpace) {
+        for bb in &self.blackboards {
+            let addr = bb.addr();
+            let fp = bb.state_fingerprint();
+            space.write_at(addr, fp);
+            if let Some(node) = space.read_mut(addr) {
+                node.label = Some(format!("blackboard:{}", bb.agent_id));
+            }
+        }
+    }
+
+    /// List all blackboards
+    pub fn list(&self) -> &[AgentBlackboard] {
+        &self.blackboards
+    }
+}
+
+impl Default for BlackboardRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blackboard_slot_mapping() {
+        let bb = AgentBlackboard::new(0x03, "researcher");
+        assert_eq!(bb.addr(), Addr::new(PREFIX_BLACKBOARD, 0x03));
+        assert_eq!(bb.agent_addr(), Addr::new(PREFIX_AGENTS, 0x03));
+    }
+
+    #[test]
+    fn test_ice_cake() {
+        let mut bb = AgentBlackboard::new(0, "test");
+        bb.ice_cake("Use analytical style for this task");
+        assert_eq!(bb.awareness.ice_caked.len(), 1);
+    }
+
+    #[test]
+    fn test_knowledge_learning() {
+        let mut bb = AgentBlackboard::new(0, "test");
+        bb.learn_address(0x8001);
+        bb.learn_address(0x8001); // Duplicate
+        bb.learn_address(0x8002);
+        assert_eq!(bb.knowledge_addrs.len(), 2);
+    }
+
+    #[test]
+    fn test_state_fingerprint_changes_with_state() {
+        let mut bb = AgentBlackboard::new(0, "test");
+        let fp1 = bb.state_fingerprint();
+        bb.learn_address(0x8001);
+        let fp2 = bb.state_fingerprint();
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_yaml_roundtrip() {
+        let bb = AgentBlackboard::new(5, "agent-5");
+        let yaml = bb.to_yaml();
+        assert!(yaml.contains("agent_slot: 5"));
+        assert!(yaml.contains("agent-5"));
+    }
+}

--- a/src/orchestration/crew_bridge.rs
+++ b/src/orchestration/crew_bridge.rs
@@ -1,0 +1,409 @@
+//! Crew Bridge — Zero-copy crewAI integration via Arrow Flight
+//!
+//! This module bridges crewAI's Python orchestration with ladybug-rs's
+//! cognitive substrate. It provides:
+//!
+//! 1. Task dispatch from crewAI crews to ladybug-rs agents
+//! 2. Zero-copy Arrow Flight transport for fingerprint/knowledge transfer
+//! 3. sci/v1 endpoint routing for research-capable agents
+//! 4. Thinking style resolution from YAML templates
+//!
+//! # Integration Model
+//!
+//! ```text
+//! crewAI (Python)                  ladybug-rs (Rust)
+//! ─────────────────                ─────────────────────
+//!
+//! Crew.kickoff() ──► Arrow Flight DoAction("crew.dispatch") ──► CrewBridge
+//!                                                                    │
+//!   agents.yaml  ──► DoAction("crew.register_agent")  ──► AgentRegistry (0x0C)
+//!   tasks.yaml   ──► DoAction("crew.submit_task")     ──► TaskQueue
+//!   styles.yaml  ──► DoAction("crew.register_style")  ──► ThinkingTemplateRegistry (0x0D)
+//!                                                                    │
+//!   DoGet("agents")  ◄── zero-copy agent list                       │
+//!   DoGet("sci:...")  ◄── sci/v1 statistical results                │
+//!   DoAction("a2a.*") ◄──► agent-to-agent messaging (0x0F)         │
+//! ```
+//!
+//! # Non-blocking Design
+//!
+//! The bridge does NOT embed crewAI logic. It provides endpoints that
+//! crewAI's Python process calls via Arrow Flight. ladybug-rs stays
+//! standalone — if crewAI is not connected, these endpoints simply
+//! return empty results or are not called.
+
+use serde::{Deserialize, Serialize};
+use crate::storage::bind_space::{Addr, BindSpace, FINGERPRINT_WORDS};
+use super::agent_card::{AgentCard, AgentRegistry};
+use super::thinking_template::{ThinkingTemplate, ThinkingTemplateRegistry};
+use super::blackboard_agent::{AgentBlackboard, BlackboardRegistry};
+use super::a2a::{A2AProtocol, A2AMessage, DeliveryStatus};
+
+/// Task status in the dispatch pipeline
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TaskStatus {
+    Queued,
+    Assigned,
+    InProgress,
+    Completed,
+    Failed,
+    Delegated,
+}
+
+/// A task submitted by crewAI for execution
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CrewTask {
+    pub id: String,
+    pub description: String,
+    pub expected_output: String,
+    /// Agent ID to assign this task to
+    pub agent_id: Option<String>,
+    /// Thinking style override for this task
+    pub thinking_style: Option<String>,
+    /// Whether to use sci/v1 validation
+    pub require_validation: bool,
+    /// Task dependencies (IDs that must complete first)
+    pub depends_on: Vec<String>,
+    pub status: TaskStatus,
+    /// Assigned agent slot (set by dispatcher)
+    #[serde(skip)]
+    pub assigned_slot: Option<u8>,
+}
+
+/// Result from a dispatch operation
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DispatchResult {
+    pub task_id: String,
+    pub status: TaskStatus,
+    pub agent_slot: Option<u8>,
+    pub message: String,
+}
+
+/// Crew dispatch coordinator
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CrewDispatch {
+    pub crew_id: String,
+    pub tasks: Vec<CrewTask>,
+    pub process: String, // "sequential" or "hierarchical"
+}
+
+/// The main bridge between crewAI and ladybug-rs
+pub struct CrewBridge {
+    pub agents: AgentRegistry,
+    pub templates: ThinkingTemplateRegistry,
+    pub blackboards: BlackboardRegistry,
+    pub a2a: A2AProtocol,
+    task_queue: Vec<CrewTask>,
+    completed: Vec<DispatchResult>,
+}
+
+impl CrewBridge {
+    pub fn new() -> Self {
+        Self {
+            agents: AgentRegistry::new(),
+            templates: ThinkingTemplateRegistry::default(),
+            blackboards: BlackboardRegistry::new(),
+            a2a: A2AProtocol::new(),
+            task_queue: Vec::new(),
+            completed: Vec::new(),
+        }
+    }
+
+    /// Register an agent from YAML definition
+    pub fn register_agent(&mut self, card: AgentCard) -> Result<Addr, String> {
+        let id = card.id.clone();
+        let addr = self.agents.register(card)?;
+        let slot = addr.slot();
+
+        // Create matching blackboard
+        self.blackboards.create(slot, &id);
+
+        Ok(addr)
+    }
+
+    /// Register agents from YAML string (crewAI agents.yaml format)
+    pub fn register_agents_yaml(&mut self, yaml: &str) -> Result<Vec<Addr>, String> {
+        let cards = AgentRegistry::from_yaml(yaml)?;
+        let mut addrs = Vec::new();
+        for card in cards {
+            addrs.push(self.register_agent(card)?);
+        }
+        Ok(addrs)
+    }
+
+    /// Register a thinking template
+    pub fn register_template(&mut self, template: ThinkingTemplate) -> Result<Addr, String> {
+        self.templates.register(template)
+    }
+
+    /// Register templates from YAML string
+    pub fn register_templates_yaml(&mut self, yaml: &str) -> Result<Vec<Addr>, String> {
+        let templates = ThinkingTemplateRegistry::from_yaml(yaml)?;
+        let mut addrs = Vec::new();
+        for t in templates {
+            addrs.push(self.register_template(t)?);
+        }
+        Ok(addrs)
+    }
+
+    /// Submit a task for dispatch
+    pub fn submit_task(&mut self, task: CrewTask) -> DispatchResult {
+        let task_id = task.id.clone();
+
+        // Try to auto-assign if agent_id specified
+        if let Some(agent_id) = task.agent_id.clone() {
+            if let Some(agent) = self.agents.get_by_id(&agent_id) {
+                let slot = agent.slot;
+                let mut task = task;
+                task.assigned_slot = slot;
+                task.status = TaskStatus::Assigned;
+
+                // Update blackboard
+                if let Some(s) = slot {
+                    if let Some(bb) = self.blackboards.get_mut(s) {
+                        bb.awareness.active_goals.push(task.description.clone());
+
+                        // Apply thinking style if specified
+                        if let Some(ref style_name) = task.thinking_style {
+                            if let Some(template) = self.templates.get(style_name) {
+                                bb.set_thinking_style(template.resolve_base());
+                            }
+                        }
+                    }
+                }
+
+                let result = DispatchResult {
+                    task_id: task_id.clone(),
+                    status: TaskStatus::Assigned,
+                    agent_slot: slot,
+                    message: format!("Assigned to agent {}", agent_id),
+                };
+
+                self.task_queue.push(task);
+                return result;
+            }
+        }
+
+        // Queue for later assignment
+        let mut task = task;
+        task.status = TaskStatus::Queued;
+        self.task_queue.push(task);
+
+        DispatchResult {
+            task_id,
+            status: TaskStatus::Queued,
+            agent_slot: None,
+            message: "Queued for assignment".to_string(),
+        }
+    }
+
+    /// Submit a full crew dispatch
+    pub fn dispatch_crew(&mut self, dispatch: CrewDispatch) -> Vec<DispatchResult> {
+        let mut results = Vec::new();
+        match dispatch.process.as_str() {
+            "sequential" => {
+                for task in dispatch.tasks {
+                    results.push(self.submit_task(task));
+                }
+            }
+            "hierarchical" => {
+                // In hierarchical mode, first task goes to manager agent,
+                // which can then delegate via A2A
+                for task in dispatch.tasks {
+                    results.push(self.submit_task(task));
+                }
+            }
+            _ => {
+                for task in dispatch.tasks {
+                    results.push(self.submit_task(task));
+                }
+            }
+        }
+        results
+    }
+
+    /// Complete a task
+    pub fn complete_task(&mut self, task_id: &str, outcome: &str) -> Option<DispatchResult> {
+        if let Some(task) = self.task_queue.iter_mut().find(|t| t.id == task_id) {
+            task.status = TaskStatus::Completed;
+
+            // Update blackboard
+            if let Some(slot) = task.assigned_slot {
+                if let Some(bb) = self.blackboards.get_mut(slot) {
+                    let style = task.thinking_style.as_deref().unwrap_or("deliberate");
+                    bb.record_task(task_id, &task.description, outcome, style);
+                    bb.tick();
+                }
+            }
+
+            let result = DispatchResult {
+                task_id: task_id.to_string(),
+                status: TaskStatus::Completed,
+                agent_slot: task.assigned_slot,
+                message: outcome.to_string(),
+            };
+
+            self.completed.push(result.clone());
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    /// Send an A2A message between agents
+    pub fn send_a2a(&mut self, msg: A2AMessage, space: &mut BindSpace) -> DeliveryStatus {
+        self.a2a.send(msg, space)
+    }
+
+    /// Receive A2A messages for an agent
+    pub fn receive_a2a(&mut self, agent_slot: u8) -> Vec<A2AMessage> {
+        self.a2a.receive(agent_slot)
+    }
+
+    /// Bind all state into BindSpace (agents, templates, blackboards)
+    pub fn bind_all(&self, space: &mut BindSpace) {
+        self.agents.bind_all(space);
+        self.templates.bind_all(space);
+        self.blackboards.bind_all(space);
+    }
+
+    /// Get task queue
+    pub fn task_queue(&self) -> &[CrewTask] {
+        &self.task_queue
+    }
+
+    /// Get completed results
+    pub fn completed(&self) -> &[DispatchResult] {
+        &self.completed
+    }
+
+    /// Summary of bridge state (for handover / MCP status)
+    pub fn status_summary(&self) -> BridgeStatus {
+        BridgeStatus {
+            agents_registered: self.agents.count(),
+            templates_registered: self.templates.list().len(),
+            tasks_queued: self.task_queue.iter().filter(|t| t.status == TaskStatus::Queued).count(),
+            tasks_in_progress: self.task_queue.iter().filter(|t| t.status == TaskStatus::InProgress).count(),
+            tasks_completed: self.completed.len(),
+            a2a_channels: self.a2a.channels().len(),
+        }
+    }
+}
+
+impl Default for CrewBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Bridge status summary
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BridgeStatus {
+    pub agents_registered: usize,
+    pub templates_registered: usize,
+    pub tasks_queued: usize,
+    pub tasks_in_progress: usize,
+    pub tasks_completed: usize,
+    pub a2a_channels: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::agent_card::{AgentRole, AgentGoal};
+
+    fn test_agent(id: &str) -> AgentCard {
+        AgentCard {
+            id: id.to_string(),
+            name: id.to_string(),
+            role: AgentRole {
+                name: id.to_string(),
+                description: format!("{} role", id),
+            },
+            goal: AgentGoal {
+                objective: format!("{} objective", id),
+                success_criteria: vec![],
+                constraints: vec![],
+            },
+            thinking_style: "analytical".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_register_and_dispatch() {
+        let mut bridge = CrewBridge::new();
+
+        // Register agents
+        let addr = bridge.register_agent(test_agent("researcher")).unwrap();
+        assert_eq!(addr.prefix(), 0x0C);
+        assert_eq!(addr.slot(), 0);
+
+        // Submit task
+        let task = CrewTask {
+            id: "task-1".to_string(),
+            description: "Research quantum computing".to_string(),
+            expected_output: "Summary report".to_string(),
+            agent_id: Some("researcher".to_string()),
+            thinking_style: None,
+            require_validation: false,
+            depends_on: vec![],
+            status: TaskStatus::Queued,
+            assigned_slot: None,
+        };
+
+        let result = bridge.submit_task(task);
+        assert_eq!(result.status, TaskStatus::Assigned);
+        assert_eq!(result.agent_slot, Some(0));
+    }
+
+    #[test]
+    fn test_full_crew_dispatch() {
+        let mut bridge = CrewBridge::new();
+
+        bridge.register_agent(test_agent("researcher")).unwrap();
+        bridge.register_agent(test_agent("writer")).unwrap();
+
+        let dispatch = CrewDispatch {
+            crew_id: "crew-1".to_string(),
+            tasks: vec![
+                CrewTask {
+                    id: "t1".to_string(),
+                    description: "Research topic".to_string(),
+                    expected_output: "Notes".to_string(),
+                    agent_id: Some("researcher".to_string()),
+                    thinking_style: None,
+                    require_validation: true,
+                    depends_on: vec![],
+                    status: TaskStatus::Queued,
+                    assigned_slot: None,
+                },
+                CrewTask {
+                    id: "t2".to_string(),
+                    description: "Write report".to_string(),
+                    expected_output: "Report".to_string(),
+                    agent_id: Some("writer".to_string()),
+                    thinking_style: Some("creative".to_string()),
+                    require_validation: false,
+                    depends_on: vec!["t1".to_string()],
+                    status: TaskStatus::Queued,
+                    assigned_slot: None,
+                },
+            ],
+            process: "sequential".to_string(),
+        };
+
+        let results = bridge.dispatch_crew(dispatch);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].status, TaskStatus::Assigned);
+        assert_eq!(results[1].status, TaskStatus::Assigned);
+    }
+
+    #[test]
+    fn test_status_summary() {
+        let bridge = CrewBridge::new();
+        let status = bridge.status_summary();
+        assert_eq!(status.agents_registered, 0);
+        assert_eq!(status.templates_registered, 12); // base styles
+    }
+}

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -1,0 +1,86 @@
+//! Orchestration Module — crewAI Integration Layer
+//!
+//! Non-blocking, modular expansion that turns crewAI into an orchestration layer
+//! while ladybug-rs provides ice-caked blackboard awareness with agent-specific
+//! goals, tools, thinking styles, and personal awareness.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────────────────┐
+//! │                         crewAI (Python)                                  │
+//! │                                                                          │
+//! │   agents.yaml ──► AgentCard ──► BindSpace 0x0C:XX (Agent Registry)      │
+//! │   tasks.yaml  ──► TaskSpec  ──► Fluid zone (working memory)             │
+//! │   styles.yaml ──► Template  ──► BindSpace 0x0D:XX (Thinking Styles)     │
+//! │                                                                          │
+//! │   Agent A ◄──── A2A ────► Agent B                                       │
+//! │       │         (0x0F)        │                                          │
+//! │       ▼                       ▼                                          │
+//! │   Blackboard A            Blackboard B                                  │
+//! │   (0x0E:slot_a)           (0x0E:slot_b)                                 │
+//! │       │                       │                                          │
+//! │       └───────────┬───────────┘                                          │
+//! │                   ▼                                                      │
+//! │            Arrow Flight (zero-copy)                                      │
+//! │                   │                                                      │
+//! └───────────────────┼──────────────────────────────────────────────────────┘
+//!                     ▼
+//! ┌──────────────────────────────────────────────────────────────────────────┐
+//! │                      ladybug-rs (Rust)                                   │
+//! │                                                                          │
+//! │   BindSpace                                                             │
+//! │   ├── 0x0C: Agent Registry (256 agent cards)                            │
+//! │   ├── 0x0D: Thinking Templates (12 styles × 21 variants = 252 slots)   │
+//! │   ├── 0x0E: Agent Blackboards (256 per-agent state snapshots)           │
+//! │   ├── 0x0F: A2A Channels (256 message routing slots)                   │
+//! │   │                                                                     │
+//! │   ├── Surface 0x00-0x0B: Existing cognitive substrate (unchanged)       │
+//! │   ├── Fluid  0x10-0x7F: Working memory + agent task state              │
+//! │   └── Nodes  0x80-0xFF: Universal bind space (unchanged)               │
+//! │                                                                          │
+//! │   sci/v1/* ──► Statistical validation for research agents               │
+//! │   HDR cascade ──► Similarity search for RAG agents                     │
+//! │   CogRedis ──► DN.*/CAM.*/DAG.* for all agent operations              │
+//! └──────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Prefix Allocation (0x0C-0x0F)
+//!
+//! | Prefix | Purpose | Slot Layout |
+//! |--------|---------|-------------|
+//! | 0x0C | Agent Registry | 0x00-0x7F: agent cards, 0x80-0xFF: capabilities |
+//! | 0x0D | Thinking Styles | 0x00-0x0B: 12 base styles, 0x0C-0xFF: variants |
+//! | 0x0E | Blackboard | 0x00-0xFF: per-agent state (matches agent slot) |
+//! | 0x0F | A2A Routing | 0x00-0xFF: message channels (sender:receiver pairs) |
+
+pub mod agent_card;
+pub mod thinking_template;
+pub mod a2a;
+pub mod blackboard_agent;
+pub mod crew_bridge;
+
+pub use agent_card::{
+    AgentCard, AgentCapability, AgentRole, AgentGoal,
+    AgentRegistry,
+};
+
+pub use thinking_template::{
+    ThinkingTemplate, ThinkingTemplateRegistry,
+    StyleOverride,
+};
+
+pub use a2a::{
+    A2AMessage, A2AChannel, A2AProtocol,
+    MessageKind, DeliveryStatus,
+};
+
+pub use blackboard_agent::{
+    AgentBlackboard, AgentAwareness,
+    BlackboardRegistry,
+};
+
+pub use crew_bridge::{
+    CrewBridge, CrewTask, CrewDispatch,
+    TaskStatus, DispatchResult,
+};

--- a/src/orchestration/thinking_template.rs
+++ b/src/orchestration/thinking_template.rs
@@ -1,0 +1,307 @@
+//! Thinking Templates — YAML thinking styles mapped to BindSpace 0x0D
+//!
+//! Bridges crewAI's YAML-based agent configuration with ladybug-rs's 12 thinking
+//! styles and their FieldModulation parameters.
+//!
+//! # Prefix 0x0D Layout
+//!
+//! ```text
+//! Slot 0x00-0x0B: 12 base ThinkingStyle fingerprints (one per style)
+//! Slot 0x0C-0xFF: Custom variants / overrides (up to 244 templates)
+//! ```
+//!
+//! Each slot stores a fingerprint encoding the style's FieldModulation parameters
+//! so agents can find compatible thinking styles via HDR resonance search.
+
+use serde::{Deserialize, Serialize};
+use crate::cognitive::{ThinkingStyle, FieldModulation};
+use crate::storage::bind_space::{
+    Addr, BindSpace, FINGERPRINT_WORDS, PREFIX_THINKING,
+};
+
+/// Style override — allows YAML templates to fine-tune FieldModulation
+/// Any field left as None inherits from the base ThinkingStyle.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StyleOverride {
+    pub resonance_threshold: Option<f32>,
+    pub fan_out: Option<usize>,
+    pub depth_bias: Option<f32>,
+    pub breadth_bias: Option<f32>,
+    pub noise_tolerance: Option<f32>,
+    pub speed_bias: Option<f32>,
+    pub exploration: Option<f32>,
+}
+
+impl StyleOverride {
+    /// Apply overrides on top of a base FieldModulation
+    pub fn apply(&self, base: &FieldModulation) -> FieldModulation {
+        FieldModulation {
+            resonance_threshold: self.resonance_threshold.unwrap_or(base.resonance_threshold),
+            fan_out: self.fan_out.unwrap_or(base.fan_out),
+            depth_bias: self.depth_bias.unwrap_or(base.depth_bias),
+            breadth_bias: self.breadth_bias.unwrap_or(base.breadth_bias),
+            noise_tolerance: self.noise_tolerance.unwrap_or(base.noise_tolerance),
+            speed_bias: self.speed_bias.unwrap_or(base.speed_bias),
+            exploration: self.exploration.unwrap_or(base.exploration),
+        }
+    }
+}
+
+/// Thinking template — a named thinking style with optional overrides.
+///
+/// This is what gets defined in YAML:
+/// ```yaml
+/// templates:
+///   - name: "deep_research"
+///     base_style: "analytical"
+///     overrides:
+///       resonance_threshold: 0.90
+///       depth_bias: 1.0
+///       noise_tolerance: 0.02
+///   - name: "brainstorm"
+///     base_style: "creative"
+///     overrides:
+///       fan_out: 20
+///       exploration: 0.95
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ThinkingTemplate {
+    pub name: String,
+    pub base_style: String,
+    #[serde(default)]
+    pub overrides: StyleOverride,
+    #[serde(default)]
+    pub description: String,
+    /// Assigned slot in 0x0D prefix (set by registry)
+    #[serde(skip)]
+    pub slot: Option<u8>,
+}
+
+impl ThinkingTemplate {
+    /// Resolve the base ThinkingStyle enum variant
+    pub fn resolve_base(&self) -> ThinkingStyle {
+        match self.base_style.to_lowercase().as_str() {
+            "analytical" => ThinkingStyle::Analytical,
+            "convergent" => ThinkingStyle::Convergent,
+            "systematic" => ThinkingStyle::Systematic,
+            "creative" => ThinkingStyle::Creative,
+            "divergent" => ThinkingStyle::Divergent,
+            "exploratory" => ThinkingStyle::Exploratory,
+            "focused" => ThinkingStyle::Focused,
+            "diffuse" => ThinkingStyle::Diffuse,
+            "peripheral" => ThinkingStyle::Peripheral,
+            "intuitive" => ThinkingStyle::Intuitive,
+            "deliberate" => ThinkingStyle::Deliberate,
+            "metacognitive" => ThinkingStyle::Metacognitive,
+            _ => ThinkingStyle::Deliberate,
+        }
+    }
+
+    /// Compute the effective FieldModulation (base + overrides)
+    pub fn effective_modulation(&self) -> FieldModulation {
+        let base = self.resolve_base().field_modulation();
+        self.overrides.apply(&base)
+    }
+
+    /// Encode FieldModulation as a fingerprint for BindSpace storage.
+    ///
+    /// The 7 modulation parameters are encoded into the first 7 words
+    /// of the fingerprint as f32-expanded bit patterns, enabling
+    /// Hamming-based similarity search between thinking styles.
+    pub fn modulation_fingerprint(&self) -> [u64; FINGERPRINT_WORDS] {
+        let m = self.effective_modulation();
+        let mut fp = [0u64; FINGERPRINT_WORDS];
+
+        // Encode each parameter into bit patterns across fingerprint words
+        // Using thermometer coding: set bits proportional to parameter value
+        let params = [
+            m.resonance_threshold,
+            m.fan_out as f32 / 20.0, // Normalize fan_out to 0..1 range
+            m.depth_bias,
+            m.breadth_bias,
+            m.noise_tolerance,
+            m.speed_bias,
+            m.exploration,
+        ];
+
+        for (i, &param) in params.iter().enumerate() {
+            let bits_to_set = (param * 64.0_f32).round() as u32;
+            // Set `bits_to_set` bits in word group starting at i*22
+            let base_word = i * 22;
+            for w in 0..22 {
+                if base_word + w >= FINGERPRINT_WORDS {
+                    break;
+                }
+                let bits_for_word = bits_to_set.min(64);
+                fp[base_word + w] = if bits_for_word >= 64 {
+                    u64::MAX
+                } else {
+                    (1u64 << bits_for_word) - 1
+                };
+            }
+        }
+        fp
+    }
+
+    /// Get BindSpace address for this template
+    pub fn addr(&self) -> Option<Addr> {
+        self.slot.map(|s| Addr::new(PREFIX_THINKING, s))
+    }
+}
+
+/// Registry of thinking templates
+pub struct ThinkingTemplateRegistry {
+    templates: Vec<ThinkingTemplate>,
+    next_custom_slot: u8,
+}
+
+impl ThinkingTemplateRegistry {
+    pub fn new() -> Self {
+        Self {
+            templates: Vec::new(),
+            // First 12 slots (0x00-0x0B) reserved for base styles
+            next_custom_slot: 0x0C,
+        }
+    }
+
+    /// Seed the 12 base ThinkingStyle templates into slots 0x00-0x0B
+    pub fn seed_base_styles(&mut self) {
+        for (i, style) in ThinkingStyle::ALL.iter().enumerate() {
+            let template = ThinkingTemplate {
+                name: format!("{:?}", style).to_lowercase(),
+                base_style: format!("{:?}", style).to_lowercase(),
+                overrides: StyleOverride::default(),
+                description: format!("Base {} thinking style", style),
+                slot: Some(i as u8),
+            };
+            self.templates.push(template);
+        }
+    }
+
+    /// Register a custom template in the next available slot
+    pub fn register(&mut self, mut template: ThinkingTemplate) -> Result<Addr, String> {
+        if self.next_custom_slot == 0xFF {
+            return Err("Template registry full (244 custom max)".to_string());
+        }
+
+        template.slot = Some(self.next_custom_slot);
+        let addr = Addr::new(PREFIX_THINKING, self.next_custom_slot);
+        self.templates.push(template);
+        self.next_custom_slot += 1;
+        Ok(addr)
+    }
+
+    /// Bind all templates into BindSpace
+    pub fn bind_all(&self, space: &mut BindSpace) {
+        for template in &self.templates {
+            if let Some(slot) = template.slot {
+                let addr = Addr::new(PREFIX_THINKING, slot);
+                let fp = template.modulation_fingerprint();
+                space.write_at(addr, fp);
+                if let Some(node) = space.read_mut(addr) {
+                    node.label = Some(format!("style:{}", template.name));
+                }
+            }
+        }
+    }
+
+    /// Parse templates from YAML
+    pub fn from_yaml(yaml: &str) -> Result<Vec<ThinkingTemplate>, String> {
+        #[derive(Deserialize)]
+        struct TemplateList {
+            templates: Vec<ThinkingTemplate>,
+        }
+        let list: TemplateList = serde_yml::from_str(yaml)
+            .map_err(|e| format!("YAML parse error: {}", e))?;
+        Ok(list.templates)
+    }
+
+    /// Find template by name
+    pub fn get(&self, name: &str) -> Option<&ThinkingTemplate> {
+        self.templates.iter().find(|t| t.name == name)
+    }
+
+    /// Get template by slot
+    pub fn get_by_slot(&self, slot: u8) -> Option<&ThinkingTemplate> {
+        self.templates.iter().find(|t| t.slot == Some(slot))
+    }
+
+    /// List all registered templates
+    pub fn list(&self) -> &[ThinkingTemplate] {
+        &self.templates
+    }
+}
+
+impl Default for ThinkingTemplateRegistry {
+    fn default() -> Self {
+        let mut reg = Self::new();
+        reg.seed_base_styles();
+        reg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_style_override_apply() {
+        let base = ThinkingStyle::Analytical.field_modulation();
+        let over = StyleOverride {
+            resonance_threshold: Some(0.95),
+            fan_out: Some(1),
+            ..Default::default()
+        };
+        let effective = over.apply(&base);
+        assert!((effective.resonance_threshold - 0.95).abs() < f32::EPSILON);
+        assert_eq!(effective.fan_out, 1);
+        // Unchanged fields inherit from base
+        assert!((effective.depth_bias - base.depth_bias).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_yaml_template_parse() {
+        let yaml = r#"
+templates:
+  - name: "deep_research"
+    base_style: "analytical"
+    description: "Deep statistical research"
+    overrides:
+      resonance_threshold: 0.95
+      depth_bias: 1.0
+  - name: "brainstorm"
+    base_style: "creative"
+    overrides:
+      fan_out: 20
+      exploration: 0.95
+"#;
+        let templates = ThinkingTemplateRegistry::from_yaml(yaml).unwrap();
+        assert_eq!(templates.len(), 2);
+        assert_eq!(templates[0].name, "deep_research");
+        assert_eq!(templates[0].resolve_base(), ThinkingStyle::Analytical);
+        assert_eq!(templates[1].resolve_base(), ThinkingStyle::Creative);
+    }
+
+    #[test]
+    fn test_base_styles_seeded() {
+        let reg = ThinkingTemplateRegistry::default();
+        assert_eq!(reg.list().len(), 12);
+        // First slot should be the first style
+        let first = reg.get_by_slot(0).unwrap();
+        assert_eq!(first.resolve_base(), ThinkingStyle::Analytical);
+    }
+
+    #[test]
+    fn test_modulation_fingerprint_deterministic() {
+        let t = ThinkingTemplate {
+            name: "test".to_string(),
+            base_style: "creative".to_string(),
+            overrides: StyleOverride::default(),
+            description: String::new(),
+            slot: None,
+        };
+        let fp1 = t.modulation_fingerprint();
+        let fp2 = t.modulation_fingerprint();
+        assert_eq!(fp1, fp2);
+    }
+}

--- a/src/storage/bind_space.rs
+++ b/src/storage/bind_space.rs
@@ -13,11 +13,11 @@
 //! │                 │  0x02: Cypher/GQL    0x0A: Memory ops                     │
 //! │                 │       (0x00-0x7F: Cypher, 0x80-0xFF: GQL)                 │
 //! │                 │  0x03: GraphQL       0x0B: Learning ops                   │
-//! │                 │  0x04: NARS/ACT-R    0x0C: Reserved                       │
+//! │                 │  0x04: NARS/ACT-R    0x0C: Agents (crewai)               │
 //! │                 │       (0x00-0x7F: NARS, 0x80-0xFF: ACT-R)                 │
-//! │                 │  0x05: Causal        0x0D: Reserved                       │
-//! │                 │  0x06: Meta          0x0E: Reserved                       │
-//! │                 │  0x07: Verbs         0x0F: Reserved                       │
+//! │                 │  0x05: Causal        0x0D: Thinking Styles               │
+//! │                 │  0x06: Meta          0x0E: Blackboard                    │
+//! │                 │  0x07: Verbs         0x0F: A2A Routing                   │
 //! ├─────────────────┼───────────────────────────────────────────────────────────┤
 //! │  0x10-0x7F:XX   │  FLUID (112 prefixes × 256 = 28,672)                      │
 //! │                 │  Edges + Context selector + Working memory                │
@@ -85,6 +85,14 @@ pub const PREFIX_RESERVED_C: u8 = 0x0C;
 pub const PREFIX_RESERVED_D: u8 = 0x0D;
 pub const PREFIX_RESERVED_E: u8 = 0x0E;
 pub const PREFIX_RESERVED_F: u8 = 0x0F;
+
+// --- Orchestration prefixes (crewai feature) ---
+// These overlay the reserved 0x0C-0x0F surface addresses.
+// Slot subdivision: 0x00-0x7F primary, 0x80-0xFF secondary (same as SQL/Cypher)
+pub const PREFIX_AGENTS: u8 = 0x0C;       // Agent registry (cards, capabilities, goals)
+pub const PREFIX_THINKING: u8 = 0x0D;     // Thinking style templates (YAML → FieldModulation)
+pub const PREFIX_BLACKBOARD: u8 = 0x0E;   // Per-agent blackboard state (ice-caked awareness)
+pub const PREFIX_A2A: u8 = 0x0F;          // Agent-to-Agent message routing channels
 
 // Slot subdivision boundary for shared prefixes
 // Slots 0x00-0x7F: primary language (SQL, Cypher, NARS)


### PR DESCRIPTION
allocates reserved prefixes 0x0C-0x0F in the 8+8 address model:
- 0x0C: Agent Registry (agent cards, capabilities, goals)
- 0x0D: Thinking Style Templates (YAML → FieldModulation)
- 0x0E: Per-agent Blackboard state (ice-caked awareness)
- 0x0F: Agent-to-Agent message routing channels

New feature-gated module `crewai` (depends on `flight`) with:
- orchestration/agent_card.rs: crewAI agents.yaml compatible agent definitions
- orchestration/thinking_template.rs: YAML thinking style templates with StyleOverride
- orchestration/a2a.rs: Agent-to-Agent protocol via XOR-composed fingerprints
- orchestration/blackboard_agent.rs: Per-agent state with knowledge tracking
- orchestration/crew_bridge.rs: Zero-copy bridge for task dispatch and crew coordination

Flight server extensions (14 new DoAction endpoints):
- crew.register_agent, crew.register_style, crew.submit_task, crew.dispatch
- crew.complete_task, crew.status, crew.bind
- a2a.send, a2a.receive
- style.resolve, style.list
- agent.list, agent.blackboard, agent.blackboard.yaml

New DoGet ticket types: agents, styles, blackboards, a2a, orchestration

Non-blocking design: standalone ladybug-rs is unaffected (default features
compile cleanly). crewAI integration is purely additive and modular.

18 new tests all passing.

https://claude.ai/code/session_01CSyicPmyQZ88KUNd2RW3Kk